### PR TITLE
User Agent を、他のエクスポータと区別できるものに変更

### DIFF
--- a/admiral_stats_exporter.py
+++ b/admiral_stats_exporter.py
@@ -89,7 +89,7 @@ os.makedirs(json_dir, exist_ok=True)
 AS_IMPORT_URL = 'https://www.admiral-stats.com/api/v1/import'
 GET_FILE_TYPES_URL = 'https://www.admiral-stats.com/api/v1/import/file_types'
 # User Agent for logging on www.admiral-stats.com
-AS_HTTP_HEADER_UA = 'AdmiralStatsExporter-Ruby/1.6.3'
+AS_HTTP_HEADER_UA = 'AdmiralStatsExporter-Python/1.0.0'
 
 import_headers = {
     'Content-Type' : 'application/json',


### PR DESCRIPTION
オリジナルの admiral_stats_exporter 開発者の @muziyoshiz です。
Python 版の開発ありがとうございます。

サーバ側のログを見ていて、Python 版も Ruby 版と同じ User Agent を送っていることに気づきました。
違う名前になっていれば、Python 版のユーザ数などもわかるようになるので、
User Agent を変更していただいてもよろしいでしょうか？

バージョン番号は仮に 1.0.0 としましたが、他の番号に変更していただいても問題ありません。
よろしくお願いします。